### PR TITLE
Typo Fixes

### DIFF
--- a/info/description.md
+++ b/info/description.md
@@ -5,7 +5,7 @@ After that, the encoder turns the grille 90 degrees clockwise.
 The symbols written earlier become hidden under the grille and clean spaces appear inside the windows.
 The encoder then writes down the next four symbols of the password in the windows and turns the grille 90 degrees again.
 Then, they write down the next four symbols and turn the grille once more.
-They the write down the final four symbols of the password.
+They then write down the final four symbols of the password.
 Without the cipher grille, it is very difficult to discern the password from the resulting square comprised of 16 symbols.
 
 Write a module that enables the robots to easily recall their passwords using a cipher grille.
@@ -21,6 +21,6 @@ X . . X     a t o n
 i . . .   . t . f   . . . .   . . d .
 . . c .   . . . .   g . . e   . d . .
 a . . n   . . o .   . t . .   . . . .
-. . . .   . r . .   . . . i   q . . i
+. . . .   . r . .   . . . i   q . d .
  ican   +  tfor   +  geti   +  ddqd
 ```

--- a/info/used.md
+++ b/info/used.md
@@ -2,5 +2,5 @@
 
 In this mission you learn how to work with 2D arrays.
 You also get to learn about Grille Ciphers,
-a technique of encoding messages which has been in use for nearly00half a millenium.
+a technique of encoding messages which has been in use for nearly half a millenium.
 The earliest known description of the grille cipher comes from the Italian mathematician, Girolamo Cardano in 1550.


### PR DESCRIPTION
- The last grille of the example showed "i" instead of "d" (but the text underneath was correct).
- Fix a typo in the description
- Fix a typo in used.md 
